### PR TITLE
Add generator for diverse sample orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ python main.py
 Abrirá el navegador en http://127.0.0.1:8080
 
 ## Columnas reconocidas en Excel/CSV
-- order_id, title, email, tags, notes, cover (hardcover/paperback), size, wants_narr, pages
+- order_id, title, email, tags, notes, cover (hardcover/paperback), size, wants_voice, pages
 (No todas son obligatorias; la app usa valores por defecto si faltan)
+
+### Órdenes de prueba
+
+Ejecuta `python generate_sample_orders.py` para crear `sample_orders.csv` con ejemplos que cubren combinaciones de etiquetas `voz` y `qr`, distintos tamaños y tipos de cubierta. Importa este archivo desde la interfaz para verificar que todo funcione correctamente.
 
 ## Empaquetar en .EXE (Windows)
 ```powershell

--- a/generate_sample_orders.py
+++ b/generate_sample_orders.py
@@ -1,0 +1,96 @@
+import csv
+from pathlib import Path
+
+ORDERS = [
+    {
+        "order_id": "1001",
+        "title": "El viaje de Luna",
+        "email": "luna@example.com",
+        "tags": "voz",
+        "notes": "Niña y su gato exploran un bosque mágico",
+        "cover": "hardcover",
+        "size": "6x9",
+        "wants_voice": "true",
+        "pages": "24",
+    },
+    {
+        "order_id": "1002",
+        "title": "El faro de Mateo",
+        "email": "mateo@example.com",
+        "tags": "qr",
+        "notes": "Niño ayuda a encender el faro antes de la tormenta",
+        "cover": "paperback",
+        "size": "5x8",
+        "wants_voice": "false",
+        "pages": "20",
+    },
+    {
+        "order_id": "1003",
+        "title": "La magia de Sofía",
+        "email": "sofia@example.com",
+        "tags": "voz,qr",
+        "notes": "Niña encuentra un libro encantado que cobra vida",
+        "cover": "hardcover",
+        "size": "8x8",
+        "wants_voice": "true",
+        "pages": "32",
+    },
+    {
+        "order_id": "1004",
+        "title": "Aventura de Diego",
+        "email": "diego@example.com",
+        "tags": "",
+        "notes": "Niño construye una nave espacial de cartón",
+        "cover": "spiral",
+        "size": "7x10",
+        "wants_voice": "false",
+        "pages": "28",
+    },
+    {
+        "order_id": "1005",
+        "title": "Misterio de Valentina",
+        "email": "valentina@example.com",
+        "tags": "qr",
+        "notes": "Valentina resuelve enigmas en un museo",
+        "cover": "paperback",
+        "size": "5x5",
+        "wants_voice": "false",
+        "pages": "30",
+    },
+    {
+        "order_id": "1006",
+        "title": "Viaje de Carla",
+        "email": "carla@example.com",
+        "tags": "voz",
+        "notes": "Carla viaja al fondo del mar con un delfín",
+        "cover": "hardcover",
+        "size": "6x6",
+        "wants_voice": "true",
+        "pages": "40",
+    },
+]
+
+FIELDNAMES = [
+    "order_id",
+    "title",
+    "email",
+    "tags",
+    "notes",
+    "cover",
+    "size",
+    "wants_voice",
+    "pages",
+]
+
+
+def main(path: Path = Path("sample_orders.csv")) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(ORDERS)
+    print(f"Generated {len(ORDERS)} orders in {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_orders.csv
+++ b/sample_orders.csv
@@ -1,3 +1,7 @@
-order_id,title,email,tags,notes,cover,size,wants_narr,pages
-1001,El viaje de Luna,luna@example.com,hardcover;6x9;foto,Niña y su gato exploran un bosque mágico,hardcover,6x9,true,24
-1002,El faro de Mateo,mateo@example.com,paperback;5x8,Niño ayuda a encender el faro antes de la tormenta,paperback,5x8,false,20
+order_id,title,email,tags,notes,cover,size,wants_voice,pages
+1001,El viaje de Luna,luna@example.com,voz,Niña y su gato exploran un bosque mágico,hardcover,6x9,true,24
+1002,El faro de Mateo,mateo@example.com,qr,Niño ayuda a encender el faro antes de la tormenta,paperback,5x8,false,20
+1003,La magia de Sofía,sofia@example.com,"voz,qr",Niña encuentra un libro encantado que cobra vida,hardcover,8x8,true,32
+1004,Aventura de Diego,diego@example.com,,Niño construye una nave espacial de cartón,spiral,7x10,false,28
+1005,Misterio de Valentina,valentina@example.com,qr,Valentina resuelve enigmas en un museo,paperback,5x5,false,30
+1006,Viaje de Carla,carla@example.com,voz,Carla viaja al fondo del mar con un delfín,hardcover,6x6,true,40


### PR DESCRIPTION
## Summary
- provide `generate_sample_orders.py` to build a CSV of varied test orders
- refresh `sample_orders.csv` with comma-separated tags and `wants_voice` flag
- document new column names and how to generate sample orders in README

## Testing
- `python -m py_compile main.py generate_sample_orders.py`
- `python generate_sample_orders.py`
- `timeout 5s python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68af803684948328a2ee36d41cd8301d