### PR TITLE
feat: implement orders and generation

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -8,3 +8,4 @@ pip install -r requirements.txt
 set ECS_HOST=127.0.0.1
 set ECS_PORT=8080
 python main.py
+pause


### PR DESCRIPTION
## Summary
- add dataclass models for orders and items with SQLite persistence
- implement CSV/XLSX import, PDF generation, and batch ZIP output
- expose NiceGUI UI with order details and simple REST API
- start server via decorators and `ui.run` so Windows `run.bat` stays open

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
from main import parse_items
print(parse_items('ABC:2@es#Titulo#Perso | DEF:1@en'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af848c0804832895293f4ce8b3a35b