### PR TITLE
refactor: add order bundling with QR and voice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pillow>=10.4
 qrcode>=7.4
 python-multipart>=0.0.9
 pikepdf>=9.2
+pyttsx3>=2.90
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- rewrite app to parse orders via a single parse_orders function
- add optional TTS voice synthesis and QR generation with zipped bundles
- expose downloads directory and sample order loader
- mount downloads without unsupported `show_index` parameter

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af8c55a0008328bb8f17e3076245a8