### PR TITLE
fix: restrict upload types with props

### DIFF
--- a/main.py
+++ b/main.py
@@ -290,7 +290,7 @@ async def handle_upload(e: UploadEventArguments) -> None:
 def import_block() -> None:
     with ui.card().classes('p-4'):
         ui.label('Importar pedidos (CSV/Excel)')
-        ui.upload(on_upload=handle_upload, auto_upload=True, accept='.csv,.xlsx,.xls')
+        ui.upload(on_upload=handle_upload, auto_upload=True).props('accept=.csv,.xlsx,.xls')
 
 
 def load_sample_orders() -> None:


### PR DESCRIPTION
## Summary
- use NiceGUI props to restrict upload to CSV/Excel instead of unsupported `accept` argument

## Testing
- `python -m py_compile main.py`
- `timeout 5 python main.py >/tmp/run.log && tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68af8e7b4d488328a8bd90f79f16ad91