### PR TITLE
fix: restrict upload types and disable autoreload

### DIFF
--- a/main.py
+++ b/main.py
@@ -290,7 +290,7 @@ async def handle_upload(e: UploadEventArguments) -> None:
 def import_block() -> None:
     with ui.card().classes('p-4'):
         ui.label('Importar pedidos (CSV/Excel)')
-        ui.upload(on_upload=handle_upload, auto_upload=True, accept='.csv,.xlsx,.xls')
+        ui.upload(on_upload=handle_upload, auto_upload=True).props('accept=.csv,.xlsx,.xls')
 
 
 def load_sample_orders() -> None:
@@ -399,5 +399,5 @@ def main_page() -> None:
 # Run app
 
 if __name__ in {'__main__', '__mp_main__'}:
-    ui.run(host='0.0.0.0', port=8080)
+    ui.run(host='0.0.0.0', port=8080, reload=False)
 


### PR DESCRIPTION
## Summary
- use NiceGUI props to restrict upload to CSV/Excel instead of unsupported `accept` argument
- disable NiceGUI autoreload to prevent reload loops during tests

## Testing
- `python -m py_compile main.py`
- `timeout 5 python main.py >/tmp/run.log && tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68af8e7b4d488328a8bd90f79f16ad91