### PR TITLE
Handle missing TTS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ python main.py
 ```
 Abrirá el navegador en http://127.0.0.1:8080
 
+> Nota: la clonación de voz con muestras requiere la librería opcional `TTS`, disponible solo para versiones de Python anteriores a 3.12. Si no está instalada, la aplicación usará `pyttsx3` con una voz genérica.
+
 ## Columnas reconocidas en Excel/CSV
 - order_id, title, email, tags, notes, cover (hardcover/paperback), size, wants_voice, pages, voice_sample
 (No todas son obligatorias; la app usa valores por defecto si faltan)

--- a/main.py
+++ b/main.py
@@ -158,10 +158,18 @@ def synth_voice(row: dict, out_dir: Path) -> Path | None:
     provider = VOICE_PROVIDER
     try:
         if row.get('voice_sample'):
-            from TTS.api import TTS
-            tts = TTS("tts_models/multilingual/multi-dataset/xtts_v2")
-            tts.tts_to_file(text=text, speaker_wav=row['voice_sample'], language="es", file_path=str(out_path))
-            return out_path
+            try:
+                from TTS.api import TTS  # type: ignore
+                tts = TTS("tts_models/multilingual/multi-dataset/xtts_v2")
+                tts.tts_to_file(
+                    text=text,
+                    speaker_wav=row['voice_sample'],
+                    language="es",
+                    file_path=str(out_path),
+                )
+                return out_path
+            except Exception as e:
+                logger.warning('TTS voice clone unavailable: %s', e)
         if provider == 'elevenlabs' and XI_API_KEY:
             import requests
             voice_id = row.get('voice_seed') or '21m00Tcm4TlvDq8ikWAM'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ python-multipart>=0.0.9
 pikepdf>=9.2
 pyttsx3>=2.90
 python-dotenv>=1.0
-TTS>=0.22.0


### PR DESCRIPTION
## Summary
- drop unsupported `TTS` requirement to prevent pip installation failures on Python 3.12
- handle optional voice cloning gracefully when `TTS` is not available
- document optional `TTS` usage in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c24b0eb083288b20ff29724595d4