### PR TITLE
Fix sample loading and cover page handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import LETTER
 from dotenv import load_dotenv, set_key
 
-from nicegui import ui, app
+from nicegui import ui, app, Client
 from nicegui.events import UploadEventArguments
 from fastapi.responses import JSONResponse, StreamingResponse
 
@@ -124,93 +124,8 @@ def books_for_cover(cover: str) -> int:
     return 2 if cover.lower() == 'premium hardcover' else 1
 
 
-def generate_prompts(row: dict) -> None:
-    """Build Gemini Storybook prompts based on order specs."""
-    specs = [f"Crea un cuento para {row['client']}"]
-    pcs = row.get('personalized_characters')
-    if pcs:
-        specs.append(f"incluye {pcs} personajes personalizados")
-    narration = row.get('narration')
-    if narration and narration.lower() != 'none':
-        specs.append(f"narración: {narration}")
-    base = '. '.join(specs) + '. No menciones número de páginas ni tipo de cubierta.'
-    prompts: list[str] = []
-    for i in range(books_for_cover(row.get('cover', ''))):
-        extra = " Continúa la historia del libro anterior." if i else ""
-        prompt_input = base + extra
-        if OPENAI_API_KEY:
-            try:
-                payload = {
-                    'model': 'gpt-4o',
-                    'messages': [
-                        {'role': 'system', 'content': 'Eres un asistente que genera prompts para Gemini Storybook.'},
-                        {'role': 'user', 'content': prompt_input},
-                    ],
-                }
-                r = requests.post('https://api.openai.com/v1/chat/completions',
-                                   headers={'Authorization': f'Bearer {OPENAI_API_KEY}'},
-                                   json=payload, timeout=20)
-                if r.status_code == 200:
-                    content = r.json()['choices'][0]['message']['content'].strip()
-                    prompts.append(content)
-                else:
-                    logger.warning('OpenAI prompt error %s: %s', r.status_code, r.text)
-                    prompts.append(prompt_input)
-            except Exception as e:
-                logger.error('OpenAI prompt failed: %s', e)
-                prompts.append(prompt_input)
-        else:
-            prompts.append(prompt_input)
-    row['prompts'] = prompts
-    row['status'] = 'Prompt ready'
-
-def books_for_cover(cover: str) -> int:
-    return 2 if cover.lower() == 'premium hardcover' else 1
-
-
-def generate_prompts(row: dict) -> None:
-    """Build Gemini Storybook prompts based on order specs."""
-    specs = [f"Crea un cuento para {row['client']}"]
-    pcs = row.get('personalized_characters')
-    if pcs:
-        specs.append(f"incluye {pcs} personajes personalizados")
-    narration = row.get('narration')
-    if narration and narration.lower() != 'none':
-        specs.append(f"narración: {narration}")
-    base = '. '.join(specs) + '. No menciones número de páginas ni tipo de cubierta.'
-    prompts: list[str] = []
-    for i in range(books_for_cover(row.get('cover', ''))):
-        extra = " Continúa la historia del libro anterior." if i else ""
-        prompt_input = base + extra
-        if OPENAI_API_KEY:
-            try:
-                payload = {
-                    'model': 'gpt-4o',
-                    'messages': [
-                        {'role': 'system', 'content': 'Eres un asistente que genera prompts para Gemini Storybook.'},
-                        {'role': 'user', 'content': prompt_input},
-                    ],
-                }
-                r = requests.post('https://api.openai.com/v1/chat/completions',
-                                   headers={'Authorization': f'Bearer {OPENAI_API_KEY}'},
-                                   json=payload, timeout=20)
-                if r.status_code == 200:
-                    content = r.json()['choices'][0]['message']['content'].strip()
-                    prompts.append(content)
-                else:
-                    logger.warning('OpenAI prompt error %s: %s', r.status_code, r.text)
-                    prompts.append(prompt_input)
-            except Exception as e:
-                logger.error('OpenAI prompt failed: %s', e)
-                prompts.append(prompt_input)
-        else:
-            prompts.append(prompt_input)
-    row['prompts'] = prompts
-    row['status'] = 'Prompt ready'
-
-
-def books_for_cover(cover: str) -> int:
-    return 2 if cover.lower() == 'premium hardcover' else 1
+def pages_for_cover(cover: str) -> int:
+    return 64 if cover.lower() == 'premium hardcover' else 32
 
 
 def generate_prompts(row: dict) -> None:
@@ -480,7 +395,7 @@ def import_block() -> None:
         ui.upload(on_upload=handle_upload, auto_upload=True).props('accept=.csv,.xlsx,.xls')
 
 
-async def load_sample_orders() -> None:
+async def load_sample_orders(client: Client) -> None:
     samples = [
         {'order': '1001', 'client': 'Ana', 'email': 'ana@example.com',
          'cover': 'Premium Hardcover', 'personalized_characters': 0,
@@ -537,7 +452,8 @@ async def load_sample_orders() -> None:
     await asyncio.gather(*(asyncio.to_thread(generate_prompts, s) for s in samples))
     ORDERS.extend(samples)
     refresh_table()
-    ui.notify('Pedidos de prueba cargados')
+    with client:
+        ui.notify('Pedidos de prueba cargados')
 
 
 def render_downloads() -> None:
@@ -562,8 +478,8 @@ async def open_storybook(row: dict) -> None:
     try:
         prompts = row.get('prompts') or []
         for p in prompts:
-            ui.open('https://gemini.google.com/gem/storybook')
             await ui.run_javascript(f"navigator.clipboard.writeText({json.dumps(p)});")
+            ui.open('https://gemini.google.com/gem/storybook')
         audio_dir = DOWNLOAD_DIR / f"order_{row['order']}_{row['id']}" / 'audio'
         audio_path = synth_voice(row, audio_dir)
         work_dir, zip_path = generate_order_bundle(row, DOWNLOAD_DIR)
@@ -597,7 +513,7 @@ def main_page() -> None:
         with ui.row():
             ui.button('EXPORTAR CSV', on_click=lambda: ui.download('/api/export.csv'))
             ui.button('REFRESCAR', on_click=refresh_table)
-            ui.button('Cargar pedidos de prueba', on_click=lambda: asyncio.create_task(load_sample_orders()))
+            ui.button('Cargar pedidos de prueba', on_click=lambda e: asyncio.create_task(load_sample_orders(e.client)))
 
     table = ui.table(columns=columns, rows=ORDERS, row_key='id')
 


### PR DESCRIPTION
## Summary
- compute pages per cover type and clean up duplicate helper definitions
- load sample orders using client context to allow notifications
- generate prompts for imported orders and copy them to clipboard before opening Storybook

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'
from pathlib import Path
from fastapi.testclient import TestClient
from main import app
client = TestClient(app)
res = client.get('/api/import', params={'temp_path': str(Path('sample_orders.csv').resolve())})
print(res.status_code)
rows = res.json().get('rows', [])
print(len(rows), rows[0]['status'], 'prompts' in rows[0], len(rows[0]['prompts']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b4e6e763e48328896202ad87b68c33