### PR TITLE
Use GPT-4o to extract order info and streamline Storybook flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ La aplicación pedirá la clave de OpenAI si no está configurada y la guardará
 
 Ejecuta `python generate_sample_orders.py` para crear `sample_orders.csv` con ejemplos que cubren combinaciones de etiquetas `voz` y `qr` y distintos tipos de cubierta. Importa este archivo desde la interfaz para verificar que todo funcione correctamente.
 
-El botón **Generar Libro** copia el primer prompt en el portapapeles y abre la página de Gemini Storybook sin descargar archivos. Para cubiertas **Premium Hardcover** aparece además un botón **Copiar Prompt 2** con la continuación del cuento (24 páginas en total: 2 libros de 10 páginas más 4 de relleno).
+El botón **Generar Storybook** abre la página de Gemini Storybook sin descargar archivos. Aparece después de pegar en NotebookLM el texto generado por GPT.
 
 ### Flujo de estados
-Cada pedido avanza por los siguientes estados: "Pending to NotebookLM" → "Pending to Storybook" → "ready to generate Book" → "Prompt 1 copiado" → "DONE". La interfaz muestra un botón de acción para continuar con el siguiente paso según corresponda.
+Cada pedido avanza por los siguientes estados: "Pending to NotebookLM" → "Pending to Storybook" → "DONE". La interfaz muestra un botón de acción para continuar con el siguiente paso según corresponda.
 
 ## Empaquetar en .EXE (Windows)
 ```powershell

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -16,6 +16,7 @@ ORDERS: list[dict] = []
 ROW_BUTTONS: dict[str, list[Button]] = {}
 api_button: Button | None = None
 
+
 def load_samples() -> None:
     """Load three sample orders and populate the table."""
     ORDERS.clear()
@@ -46,6 +47,7 @@ def prompt_api_key() -> None:
         if api_button:
             api_button.destroy()
             api_button = None
+
 
 def refresh_table() -> None:
     tree.delete(*tree.get_children())
@@ -82,7 +84,6 @@ def _place_buttons() -> None:
         x, y, w, h = bbox[0], bbox[1], bbox[2], bbox[3]
         buttons: list[Button] = []
         status = row.get('status', '')
-        premium = row.get('cover', '').lower() == 'premium hardcover'
         if status == 'Pending to NotebookLM':
             btn = Button(
                 tree,
@@ -94,52 +95,12 @@ def _place_buttons() -> None:
         elif status == 'Pending to Storybook':
             btn = Button(
                 tree,
-                text='Guardar Prompts',
-                command=lambda rid=row['id']: save_prompts(rid),
+                text='Generar Storybook',
+                command=lambda rid=row['id']: open_storybook(rid),
             )
             btn.place(x=x, y=y, width=w, height=h)
             buttons.append(btn)
-        elif status == 'ready to generate Book':
-            if premium and len(row.get('prompts', [])) > 1:
-                half = w // 2
-                btn1 = Button(
-                    tree,
-                    text='Generar Libro',
-                    command=lambda rid=row['id']: generate_order(rid),
-                )
-                btn1.place(x=x, y=y, width=half, height=h)
-                btn2 = Button(
-                    tree,
-                    text='Copiar Prompt 2',
-                    command=lambda rid=row['id']: copy_prompt2(rid),
-                )
-                btn2.place(x=x + half, y=y, width=w - half, height=h)
-                buttons.extend([btn1, btn2])
-            else:
-                btn1 = Button(
-                    tree,
-                    text='Generar Libro',
-                    command=lambda rid=row['id']: generate_order(rid),
-                )
-                btn1.place(x=x, y=y, width=w, height=h)
-                buttons.append(btn1)
         ROW_BUTTONS[row['id']] = buttons
-
-
-def generate_order(row_id: str) -> None:
-    row = next(r for r in ORDERS if r['id'] == row_id)
-    if row.get('prompts'):
-        pyperclip.copy(row['prompts'][0])
-        webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
-        row['status'] = 'Prompt 1 copiado'
-        refresh_table()
-        messagebox.showinfo('Listo', 'Prompt 1 copiado al portapapeles')
-
-def copy_prompt2(row_id: str) -> None:
-    row = next(r for r in ORDERS if r['id'] == row_id)
-    if len(row.get('prompts', [])) > 1:
-        pyperclip.copy(row['prompts'][1])
-        messagebox.showinfo('Listo', 'Prompt 2 copiado al portapapeles')
 
 
 def open_notebooklm(row_id: str) -> None:
@@ -153,14 +114,13 @@ def open_notebooklm(row_id: str) -> None:
     messagebox.showinfo('Listo', 'Texto copiado para NotebookLM')
 
 
-def save_prompts(row_id: str) -> None:
+def open_storybook(row_id: str) -> None:
     row = next(r for r in ORDERS if r['id'] == row_id)
-    text = pyperclip.paste()
-    prompts = [p.strip() for p in text.split('\n---\n') if p.strip()]
-    row['prompts'] = prompts
-    row['status'] = 'ready to generate Book'
+    webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
+    row['status'] = 'DONE'
     refresh_table()
-    messagebox.showinfo('Listo', 'Prompts guardados')
+    messagebox.showinfo('Listo', 'Abriendo Storybook')
+
 
 root = Tk()
 root.title('Endless Chapters')
@@ -204,3 +164,4 @@ if not (main.OPENAI_API_KEY and main.OPENAI_API_KEY != 'tu_openai'):
 Button(btns, text='Cargar pedidos de prueba', command=load_samples).pack(side='left', padx=5)
 
 root.mainloop()
+


### PR DESCRIPTION
## Summary
- Call GPT-4o for each order to extract a brief NotebookLM summary
- Replace intermediate prompt saving with a direct "Generar Storybook" step
- Document simplified state flow and Storybook generation button

## Testing
- `python -m py_compile main.py desktop_app.py`
- `python generate_sample_orders.py`

------
https://chatgpt.com/codex/tasks/task_e_68b56f949fbc83289560a36e3e939fcf