### PR TITLE
Send structured order info directly to NotebookLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 App local con interfaz para:
 - Importar pedidos desde Excel/CSV
-- Configurar y verificar la clave de OpenAI
-- Generar prompts por pedido automáticamente usando GPT-4o
+- Generar texto estructurado por pedido para NotebookLM
 - Subir texto (JSON o TXT) y audio (opcional)
 - Producir PDF listo para imprenta (portada color con logo, interior en grises, QR a audio)
 - Clonar voz a partir de un archivo de audio y generar locuciones del texto
@@ -21,13 +20,9 @@ py -m venv .venv
 pip install -r requirements.txt
 python desktop_app.py
 ```
-Al arrancar se solicitará tu clave de OpenAI y se abrirá una ventana vacía; pulsa "Cargar pedidos de prueba" para ver ejemplos.
+Al arrancar se abrirá una ventana vacía; pulsa "Cargar pedidos de prueba" para ver ejemplos.
 
 > Nota: la clonación de voz con muestras requiere la librería opcional `TTS`, disponible solo para versiones de Python anteriores a 3.12. Si no está instalada, la aplicación usará `pyttsx3` con una voz genérica.
-
-### Clave de API de OpenAI
-
-La aplicación pedirá la clave de OpenAI si no está configurada y la guardará en el archivo `.env`. Para cambiarla más adelante edita dicho archivo manualmente. Esta clave se utiliza para generar los prompts de Gemini Storybook con el modelo GPT-4o y para las funciones de voz que requieran OpenAI.
 
 ## Columnas reconocidas en Excel/CSV
 - order, title, email, tags, notes, cover (Premium Hardcover/Standard Hardcover), personalized_characters, narration, revisions, voice_sample
@@ -43,10 +38,10 @@ La aplicación pedirá la clave de OpenAI si no está configurada y la guardará
 
 Ejecuta `python generate_sample_orders.py` para crear `sample_orders.csv` con ejemplos que cubren combinaciones de etiquetas `voz` y `qr` y distintos tipos de cubierta. Importa este archivo desde la interfaz para verificar que todo funcione correctamente.
 
-El botón **Generar Libro** copia el primer prompt en el portapapeles y abre la página de Gemini Storybook sin descargar archivos. Para cubiertas **Premium Hardcover** aparece además un botón **Copiar Prompt 2** con la continuación del cuento (24 páginas en total: 2 libros de 10 páginas más 4 de relleno).
+El botón **Generar Storybook** abre la página de Gemini Storybook sin descargar archivos. Aparece después de copiar en NotebookLM el resumen generado allí.
 
 ### Flujo de estados
-Cada pedido avanza por los siguientes estados: "Pending to NotebookLM" → "Pending to Storybook" → "ready to generate Book" → "Prompt 1 copiado" → "DONE". La interfaz muestra un botón de acción para continuar con el siguiente paso según corresponda.
+Cada pedido avanza por los siguientes estados: "Pending to NotebookLM" → "Pending to Storybook" → "Pending yo revise PDF" → "DONE". La interfaz muestra un botón de acción para continuar con el siguiente paso según corresponda.
 
 ## Empaquetar en .EXE (Windows)
 ```powershell

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-import os
 import webbrowser
-from tkinter import Tk, Frame, Button, messagebox, simpledialog
+from tkinter import Tk, Frame, Button, messagebox
 from tkinter import ttk
 
 import pyperclip
 
-import main
-from main import generate_prompts
-from dotenv import set_key
+from main import prepare_notebook_text
 from sample_orders import get_sample_orders
 
 ORDERS: list[dict] = []
 ROW_BUTTONS: dict[str, list[Button]] = {}
-api_button: Button | None = None
+
 
 def load_samples() -> None:
     """Load three sample orders and populate the table."""
@@ -22,30 +19,13 @@ def load_samples() -> None:
     samples = get_sample_orders()
     for s in samples:
         try:
-            generate_prompts(s)
+            prepare_notebook_text(s)
             ORDERS.append(s)
         except Exception as e:
-            messagebox.showerror('Error', f'No se pudieron generar prompts: {e}')
+            messagebox.showerror('Error', f'No se pudieron preparar los datos: {e}')
             break
     refresh_table()
 
-
-def prompt_api_key() -> None:
-    """Ask the user for the OpenAI API key if not already configured."""
-    global api_button
-    if main.OPENAI_API_KEY and main.OPENAI_API_KEY != 'tu_openai':
-        if api_button:
-            api_button.destroy()
-            api_button = None
-        return
-    key = simpledialog.askstring('OpenAI API Key', 'Introduce tu clave de OpenAI:', show='*')
-    if key:
-        os.environ['OPENAI_API_KEY'] = key
-        main.OPENAI_API_KEY = key
-        set_key(str(main.BASE_DIR / '.env'), 'OPENAI_API_KEY', key)
-        if api_button:
-            api_button.destroy()
-            api_button = None
 
 def refresh_table() -> None:
     tree.delete(*tree.get_children())
@@ -82,7 +62,6 @@ def _place_buttons() -> None:
         x, y, w, h = bbox[0], bbox[1], bbox[2], bbox[3]
         buttons: list[Button] = []
         status = row.get('status', '')
-        premium = row.get('cover', '').lower() == 'premium hardcover'
         if status == 'Pending to NotebookLM':
             btn = Button(
                 tree,
@@ -94,52 +73,12 @@ def _place_buttons() -> None:
         elif status == 'Pending to Storybook':
             btn = Button(
                 tree,
-                text='Guardar Prompts',
-                command=lambda rid=row['id']: save_prompts(rid),
+                text='Generar Storybook',
+                command=lambda rid=row['id']: open_storybook(rid),
             )
             btn.place(x=x, y=y, width=w, height=h)
             buttons.append(btn)
-        elif status == 'ready to generate Book':
-            if premium and len(row.get('prompts', [])) > 1:
-                half = w // 2
-                btn1 = Button(
-                    tree,
-                    text='Generar Libro',
-                    command=lambda rid=row['id']: generate_order(rid),
-                )
-                btn1.place(x=x, y=y, width=half, height=h)
-                btn2 = Button(
-                    tree,
-                    text='Copiar Prompt 2',
-                    command=lambda rid=row['id']: copy_prompt2(rid),
-                )
-                btn2.place(x=x + half, y=y, width=w - half, height=h)
-                buttons.extend([btn1, btn2])
-            else:
-                btn1 = Button(
-                    tree,
-                    text='Generar Libro',
-                    command=lambda rid=row['id']: generate_order(rid),
-                )
-                btn1.place(x=x, y=y, width=w, height=h)
-                buttons.append(btn1)
         ROW_BUTTONS[row['id']] = buttons
-
-
-def generate_order(row_id: str) -> None:
-    row = next(r for r in ORDERS if r['id'] == row_id)
-    if row.get('prompts'):
-        pyperclip.copy(row['prompts'][0])
-        webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
-        row['status'] = 'Prompt 1 copiado'
-        refresh_table()
-        messagebox.showinfo('Listo', 'Prompt 1 copiado al portapapeles')
-
-def copy_prompt2(row_id: str) -> None:
-    row = next(r for r in ORDERS if r['id'] == row_id)
-    if len(row.get('prompts', [])) > 1:
-        pyperclip.copy(row['prompts'][1])
-        messagebox.showinfo('Listo', 'Prompt 2 copiado al portapapeles')
 
 
 def open_notebooklm(row_id: str) -> None:
@@ -153,14 +92,13 @@ def open_notebooklm(row_id: str) -> None:
     messagebox.showinfo('Listo', 'Texto copiado para NotebookLM')
 
 
-def save_prompts(row_id: str) -> None:
+def open_storybook(row_id: str) -> None:
     row = next(r for r in ORDERS if r['id'] == row_id)
-    text = pyperclip.paste()
-    prompts = [p.strip() for p in text.split('\n---\n') if p.strip()]
-    row['prompts'] = prompts
-    row['status'] = 'ready to generate Book'
+    webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
+    row['status'] = 'DONE'
     refresh_table()
-    messagebox.showinfo('Listo', 'Prompts guardados')
+    messagebox.showinfo('Listo', 'Abriendo Storybook')
+
 
 root = Tk()
 root.title('Endless Chapters')
@@ -197,10 +135,7 @@ tree.pack(fill='both', expand=True)
 # Buttons
 btns = Frame(root)
 btns.pack(pady=5)
-if not (main.OPENAI_API_KEY and main.OPENAI_API_KEY != 'tu_openai'):
-    api_button = Button(btns, text='Configurar API Key', command=prompt_api_key)
-    api_button.pack(side='left', padx=5)
-    prompt_api_key()
 Button(btns, text='Cargar pedidos de prueba', command=load_samples).pack(side='left', padx=5)
 
 root.mainloop()
+

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import qrcode
 import requests
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import LETTER
-from dotenv import load_dotenv, set_key
+from dotenv import load_dotenv
 
 from nicegui import ui, app, Client
 from nicegui.events import UploadEventArguments
@@ -81,15 +81,6 @@ def zip_dir(src: Path, zip_path: Path) -> None:
                 z.write(p, p.relative_to(src))
 
 
-def verify_openai_key(key: str) -> bool:
-    try:
-        r = requests.get('https://api.openai.com/v1/models',
-                         headers={'Authorization': f'Bearer {key}'}, timeout=10)
-        return r.status_code == 200
-    except Exception as e:
-        logger.error('verify key failed: %s', e)
-        return False
-
 # ---------------------------------------------------------------------------
 # Data model in memory
 
@@ -134,20 +125,35 @@ def pages_for_cover(cover: str) -> int:
     return 24 if cover.lower() == 'premium hardcover' else 32
 
 
-def generate_prompts(row: dict) -> None:
-    """Prepare NotebookLM source text and reset prompts."""
-    pieces: list[str] = []
+def _build_notebook_text(row: dict) -> str:
+    """Create a structured text snippet with the order information."""
+    lines: list[str] = []
+    order = row.get('order')
+    client = row.get('client')
+    if order or client:
+        lines.append(f"Pedido {order} - {client}")
+    cover = row.get('cover')
+    if cover:
+        lines.append(f"Cubierta: {cover}")
+    lines.append(f"Personajes personalizados: {row.get('personalized_characters', 0)}")
+    lines.append(f"Revisiones: {row.get('revisions', 0)}")
+    tags = row.get('tags') or []
+    if tags:
+        lines.append("Etiquetas: " + ', '.join(tags))
     story = row.get('story') or ''
     if story:
-        pieces.append(f"Historia: {story}")
+        lines.append(f"Historia: {story}")
     names = row.get('character_names') or []
     if names:
-        pieces.append("Personajes: " + ', '.join(names))
+        lines.append("Personajes: " + ', '.join(names))
     photos = row.get('photos') or []
     if photos:
-        pieces.append("Fotos de referencia: " + ', '.join(photos))
-    row['notebook_text'] = '\n'.join(pieces)
-    row['prompts'] = []
+        lines.append("Fotos de referencia: " + ', '.join(photos))
+    return "\n".join(lines)
+
+def prepare_notebook_text(row: dict) -> None:
+    """Prepare NotebookLM source text without external APIs."""
+    row['notebook_text'] = _build_notebook_text(row)
     row['status'] = 'Pending to NotebookLM'
 
 
@@ -297,7 +303,7 @@ def api_import(temp_path: str):
     try:
         rows = parse_orders(Path(temp_path))
         for r in rows:
-            generate_prompts(r)
+            prepare_notebook_text(r)
         ORDERS.extend(rows)
         return {'rows': rows}
     except Exception as e:
@@ -348,33 +354,8 @@ async def handle_upload(e: UploadEventArguments) -> None:
     ui.notify(f"{len(data['rows'])} filas importadas")
     refresh_table()
 
-def api_key_block() -> None:
-    with ui.card().classes('p-4'):
-        ui.label('Configurar OpenAI')
-        key_input = ui.input('API key', password=True, value=OPENAI_API_KEY or '').props('clearable')
-        status = ui.label('')
-
-        def verify() -> None:
-            global OPENAI_API_KEY
-            key = key_input.value.strip()
-            if not key:
-                ui.notify('Introduce una clave', type='warning')
-                return
-            if verify_openai_key(key):
-                OPENAI_API_KEY = key
-                os.environ['OPENAI_API_KEY'] = key
-                set_key(str(BASE_DIR / '.env'), 'OPENAI_API_KEY', key)
-                status.text = 'Clave verificada'
-                ui.notify('Clave verificada')
-            else:
-                status.text = 'Clave inválida'
-                ui.notify('Clave inválida', type='negative')
-
-        ui.button('Verificar', on_click=verify)
-
 
 def import_block() -> None:
-    api_key_block()
     with ui.card().classes('p-4'):
         ui.label('Importar pedidos (CSV/Excel)')
         ui.upload(on_upload=handle_upload, auto_upload=True).props('accept=.csv,.xlsx,.xls')
@@ -382,7 +363,7 @@ def import_block() -> None:
 
 async def load_sample_orders(client: Client) -> None:
     samples = get_sample_orders()
-    await asyncio.gather(*(asyncio.to_thread(generate_prompts, s) for s in samples))
+    await asyncio.gather(*(asyncio.to_thread(prepare_notebook_text, s) for s in samples))
     ORDERS.extend(samples)
     refresh_table()
     with client:
@@ -409,10 +390,7 @@ def render_downloads() -> None:
 
 async def open_storybook(row: dict, client: Client) -> None:
     try:
-        prompts = row.get('prompts') or []
-        if prompts:
-            pyperclip.copy(prompts[0])
-            webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
+        webbrowser.open('https://gemini.google.com/gem/storybook', new=2)
         audio_dir = DOWNLOAD_DIR / f"order_{row['order']}_{row['id']}" / 'audio'
         audio_path = synth_voice(row, audio_dir)
         work_dir, zip_path = generate_order_bundle(row, DOWNLOAD_DIR)
@@ -440,20 +418,6 @@ async def open_notebooklm(row: dict, client: Client) -> None:
     except Exception as e:
         with client:
             ui.notify(f'Error abriendo NotebookLM: {e}', type='negative')
-
-
-async def save_prompts(row: dict, client: Client) -> None:
-    try:
-        text = pyperclip.paste()
-        prompts = [p.strip() for p in text.split('\n---\n') if p.strip()]
-        row['prompts'] = prompts
-        row['status'] = 'ready to generate Book'
-        with client:
-            refresh_table()
-            ui.notify('Prompts guardados')
-    except Exception as e:
-        with client:
-            ui.notify(f'Error guardando prompts: {e}', type='negative')
 
 
 def mark_done(row: dict) -> None:
@@ -489,10 +453,7 @@ def main_page() -> None:
                label="NotebookLM"
                @click="() => emit('open_notebooklm', props.row.id)"/>
         <q-btn v-else-if="props.row.status === 'Pending to Storybook'"
-               label="Guardar Prompts"
-               @click="() => emit('save_prompts', props.row.id)"/>
-        <q-btn v-else-if="props.row.status === 'ready to generate Book'"
-               label="Generar Libro"
+               label="Generar Storybook"
                @click="() => emit('open_storybook', props.row.id)"/>
         <q-btn v-else-if="props.row.status === 'Pending yo revise PDF'"
                label="Marcar DONE"
@@ -507,7 +468,6 @@ def main_page() -> None:
         return next(r for r in ORDERS if r['id'] == rid)
 
     table.on('open_notebooklm', lambda e: asyncio.create_task(open_notebooklm(_row_from_event(e), e.client)))
-    table.on('save_prompts', lambda e: asyncio.create_task(save_prompts(_row_from_event(e), e.client)))
     table.on('open_storybook', lambda e: asyncio.create_task(open_storybook(_row_from_event(e), e.client)))
     table.on('mark_done', lambda e: mark_done(_row_from_event(e)))
     import_block()


### PR DESCRIPTION
## Summary
- Build NotebookLM text locally from order details, avoiding GPT calls
- Replace prompt-saving step with direct "Generar Storybook" action
- Clean up UI and docs to remove OpenAI key requirement

## Testing
- `python -m py_compile main.py desktop_app.py`
- `python generate_sample_orders.py`


------
https://chatgpt.com/codex/tasks/task_e_68b56f949fbc83289560a36e3e939fcf