### PR TITLE
Add two-part Notebook instructions for premium hardcover orders

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,16 +130,35 @@ def _build_notebook_text(row: dict) -> str:
     lines: list[str] = [
         "Genera una historia a partir de la siguiente información:",
     ]
+    cover = (row.get('cover') or '').lower()
+    photos = row.get('photos') or []
+    if cover == 'premium hardcover':
+        lines.append(
+            "La historia debe dividirse en dos partes muy claras y diferenciadas."
+        )
+        lines.append(
+            "La segunda parte debe ser la continuación de la primera, pero sin mencionarla."
+        )
+        lines.append(
+            'Genera "Parte 1" y "Parte 2", cada una con toda la información necesaria para entenderse de forma independiente.'
+        )
+        if photos:
+            lines.append("Parte 1: Hay imágenes adjuntas.")
+            lines.append("Parte 2: Hay imágenes adjuntas.")
     story = (row.get('story') or '').strip()
     if story:
         lines.append(story)
     names = row.get('character_names') or []
-    for name in names:
-        lines.append(f"{name} debe corresponder a la foto adjunta.")
-    if names:
-        lines.append(
-            "Los personajes deben corresponder a las fotos adjuntas."
-        )
+    if photos:
+        for name in names:
+            lines.append(f"{name} debe corresponder a la foto adjunta.")
+        if names:
+            lines.append(
+                "Los personajes deben corresponder a las fotos adjuntas."
+            )
+    else:
+        for name in names:
+            lines.append(name)
     return "\n".join(lines).strip()
 
 def prepare_notebook_text(row: dict) -> None:


### PR DESCRIPTION
## Summary
- Ensure premium hardcover orders generate Notebook text split into "Parte 1" and "Parte 2" with all needed context
- Only mention attached photos when images are present

## Testing
- `python -m py_compile main.py desktop_app.py generate_sample_orders.py sample_orders.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b57faefd048328ab079213ab921e19